### PR TITLE
最新の10冊のカードの高さが同じになるように修正

### DIFF
--- a/src/components/BookCard.js
+++ b/src/components/BookCard.js
@@ -11,9 +11,12 @@ const styles = {
         margin: "auto",
         marginTop: 20,
         marginBottom: 20,
+        height:350,
     },
     media: {
-        marginBottom:20,
+        marginTop: 20,
+        marginBottom: 10,
+        maxHeight:250
     }
 };
 
@@ -30,7 +33,7 @@ function BookCard(props) {
                 </Typography>
 
             </CardContent>
-            <img src={thumbnailURL} alt="bookImage" className={classes.media} />
+            <img src={thumbnailURL} alt="bookImage" className={classes.media}/>
         </Card>
     );
 }


### PR DESCRIPTION
- 仮の画像の場合でもカードに収まる
- タイトルが3行になってもカードの高さが変わらない
ように修正

<img width="320" alt="スクリーンショット 2019-04-22 9 11 55" src="https://user-images.githubusercontent.com/40712363/56477336-81392000-64df-11e9-800a-8e50fdfcd47f.png">
